### PR TITLE
feat : add .devcontainer using dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:23-bookworm-slim
+
+WORKDIR /app
+
+COPY ../* .
+
+# Install dependencies
+RUN npm install
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Node.js Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "forwardPorts": [3000],
+  "postCreateCommand": "npm run start",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "streetsidesoftware.code-spell-checker",
+        "esbenp.prettier-vscode",
+        "christian-kohler.path-intellisense",
+        "naumovs.color-highlight",
+        "formulahendry.auto-rename-tag",
+        "wix.vscode-import-cost",
+        "vscodevim.vim",
+        "alefragnani.project-manager",
+        "xabikos.JavaScriptSnippets",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
.devcontainer using extension
Dockerfile that install npm package
FROM node:23-bookworm-slim ( debian OS because alpine not supported by cursor )
run npm run start at the end to directly running node server.
